### PR TITLE
Extend FIPS to 6 characters, add region prefix

### DIFF
--- a/pgscripts/template_line_noFF_noWA_nofips.csh
+++ b/pgscripts/template_line_noFF_noWA_nofips.csh
@@ -4,6 +4,7 @@
 # - county shapefile, weight multiline shapefile (hpms roads), and grid cells geometries loaded
 # - indices on all geometry columns
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -34,7 +35,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # intersect with grid table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
   printf "\tlength_wp_cty_cell double precision default 0.1) ;\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -69,7 +70,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -87,7 +88,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
 
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -101,7 +102,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -128,8 +129,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_line_noFF_noWA_nofips.csh
+++ b/pgscripts/template_line_noFF_noWA_nofips.csh
@@ -4,8 +4,6 @@
 # - county shapefile, weight multiline shapefile (hpms roads), and grid cells geometries loaded
 # - indices on all geometry columns
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_line_withFF_noWA.csh
+++ b/pgscripts/template_line_withFF_noWA.csh
@@ -5,8 +5,6 @@
 # - indices on all geometry columns
 # - roads split by county boundaries 
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_line_withFF_noWA.csh
+++ b/pgscripts/template_line_withFF_noWA.csh
@@ -5,6 +5,7 @@
 # - indices on all geometry columns
 # - roads split by county boundaries 
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -16,7 +17,7 @@ set weight_table=$schema.$weight_shape
 
 # intersect with grid table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
   printf "\tlength_wp_cty_cell double precision default 0.1) ;\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -51,7 +52,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -69,7 +70,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
 
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -84,7 +85,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -111,8 +112,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_line_withFF_noWA_nofips.csh
+++ b/pgscripts/template_line_withFF_noWA_nofips.csh
@@ -4,6 +4,7 @@
 # - county shapefile, weight multiline shapefile (hpms roads), and grid cells geometries loaded
 # - indices on all geometry columns
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -35,7 +36,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # intersect with grid table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
   printf "\tlength_wp_cty_cell double precision default 0.1) ;\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -70,7 +71,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -88,7 +89,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
 
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -102,7 +103,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -129,8 +130,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_line_withFF_noWA_nofips.csh
+++ b/pgscripts/template_line_withFF_noWA_nofips.csh
@@ -4,8 +4,6 @@
 # - county shapefile, weight multiline shapefile (hpms roads), and grid cells geometries loaded
 # - indices on all geometry columns
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_line_withFF_withWA.csh
+++ b/pgscripts/template_line_withFF_withWA.csh
@@ -5,6 +5,7 @@
 # - indices on all geometry columns
 # - roads split by county boundaries 
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -15,7 +16,7 @@ set weight_table=$schema.$weight_shape
 
 # intersect with grid table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}  ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\t$weight_attribute  double precision default 0.1,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -52,7 +53,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -70,7 +71,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -86,7 +87,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -113,8 +114,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_line_withFF_withWA.csh
+++ b/pgscripts/template_line_withFF_withWA.csh
@@ -5,8 +5,6 @@
 # - indices on all geometry columns
 # - roads split by county boundaries 
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_point_noFF_noWA.csh
+++ b/pgscripts/template_point_noFF_noWA.csh
@@ -6,6 +6,7 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -22,7 +23,7 @@ echo "CREATE TABLE $schema.wp_cty_${surg_code} If Not Exist"
 
 printf "DROP TABLE IF EXISTS $schema.wp_cty_${surg_code}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "CREATE TABLE $schema.wp_cty_${surg_code}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
-printf "\t$data_attribute varchar(5),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\t$data_attribute varchar(6),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\tcount_wp_cty integer default 1);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "SELECT AddGeometryColumn('${schema}', 'wp_cty_${surg_code}', 'geom_${grid_proj}', ${grid_proj}, 'MULTIPOINT', 2);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "INSERT INTO $schema.wp_cty_${surg_code} (geom_${grid_proj}) \n">> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
@@ -42,7 +43,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create wp_cty_cell intersection table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "\t$data_attribute varchar(5) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\t$data_attribute varchar(6) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcount_wp_cty_cell integer default 1);\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -62,7 +63,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create denominator table
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -75,7 +76,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerator table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -93,7 +94,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create surrogate table
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -119,8 +120,8 @@ echo "CREATE TABLE $schema.surg_${surg_code}_${grid}; add primary key"
 $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_code}_surg.sql
 
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_point_noFF_noWA.csh
+++ b/pgscripts/template_point_noFF_noWA.csh
@@ -6,8 +6,6 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_point_noFF_withWA.csh
+++ b/pgscripts/template_point_noFF_withWA.csh
@@ -6,8 +6,6 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_point_noFF_withWA.csh
+++ b/pgscripts/template_point_noFF_withWA.csh
@@ -6,6 +6,7 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -22,7 +23,7 @@ echo "CREATE TABLE $schema.wp_cty_${surg_code} "
 
 printf "DROP TABLE IF EXISTS $schema.wp_cty_${surg_code}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "CREATE TABLE $schema.wp_cty_${surg_code}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
-printf "\t$data_attribute varchar(5),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\t$data_attribute varchar(6),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\t$weight_attribute double precision);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "SELECT AddGeometryColumn('${schema}', 'wp_cty_${surg_code}', 'geom_${grid_proj}', ${grid_proj}, 'MULTIPOINT', 2);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "INSERT INTO $schema.wp_cty_${surg_code} ($weight_attribute, geom_${grid_proj}) \n">> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
@@ -42,7 +43,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create wp_cty_cell intersection table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "\t$data_attribute varchar(5) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\t$data_attribute varchar(6) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\t$weight_attribute double precision) ;\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -63,7 +64,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create denominator table
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -76,7 +77,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerator table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -94,7 +95,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create surrogate table
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -120,8 +121,8 @@ echo "CREATE TABLE $schema.surg_${surg_code}_${grid}; add primary key"
 $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_code}_surg.sql
 
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_point_withFF_noWA.csh
+++ b/pgscripts/template_point_withFF_noWA.csh
@@ -6,8 +6,6 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_point_withFF_noWA.csh
+++ b/pgscripts/template_point_withFF_noWA.csh
@@ -6,6 +6,7 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -22,7 +23,7 @@ echo "CREATE TABLE $schema.wp_cty_${surg_code} "
 
 printf "DROP TABLE IF EXISTS $schema.wp_cty_${surg_code}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "CREATE TABLE $schema.wp_cty_${surg_code}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
-printf "\t$data_attribute varchar(5),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\t$data_attribute varchar(6),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\tcount_wp_cty integer default 1);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "SELECT AddGeometryColumn('${schema}', 'wp_cty_${surg_code}', 'geom_${grid_proj}', ${grid_proj}, 'MULTIPOINT', 2);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 
@@ -44,7 +45,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create wp_cty_cell intersection table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "\t$data_attribute varchar(5) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\t$data_attribute varchar(6) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcount_wp_cty_cell integer default 1);\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -64,7 +65,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create denominator table
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -77,7 +78,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerator table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -95,7 +96,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create surrogate table
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -121,8 +122,8 @@ echo "CREATE TABLE $schema.surg_${surg_code}_${grid}; add primary key"
 $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_code}_surg.sql
 
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_point_withFF_withWA.csh
+++ b/pgscripts/template_point_withFF_withWA.csh
@@ -6,8 +6,6 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 set grid_table=$schema.$grid

--- a/pgscripts/template_point_withFF_withWA.csh
+++ b/pgscripts/template_point_withFF_withWA.csh
@@ -6,6 +6,7 @@
 
 #setenv LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/nas02/apps/gcc-6.1.0/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/geos-3.5.1/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/proj-4.9.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/json-c-json-c-0.12.1-20160607/local/lib: /proj/ie/proj/CMAS/SA/spatial-Allocator/pg_srgcreate/libs/libxml2-2.9.4/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/libs/gdal-2.1.3/local/lib:/proj/ie/proj/CMAS/SA/Spatial-Allocator/pg_srgcreate/postgresql-9.5.3/lib"
 
+setenv PGPASSWORD satool
 
 VAR_DEFINITIONS
 
@@ -22,7 +23,7 @@ echo "CREATE TABLE $schema.wp_cty_${surg_code} "
 
 printf "DROP TABLE IF EXISTS $schema.wp_cty_${surg_code}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "CREATE TABLE $schema.wp_cty_${surg_code}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
-printf "\t$data_attribute varchar(5),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\t$data_attribute varchar(6),\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\t$weight_attribute double precision);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "SELECT AddGeometryColumn('${schema}', 'wp_cty_${surg_code}', 'geom_${grid_proj}', ${grid_proj}, 'MULTIPOINT', 2);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 
@@ -44,7 +45,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create wp_cty_cell intersection table
 printf "DROP TABLE IF EXISTS $schema.wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "CREATE TABLE $schema.wp_cty_cell_${surg_code}_${grid}(\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "\t$data_attribute varchar(5) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\t$data_attribute varchar(6) not null, \n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\t$weight_attribute double precision) ;\n" >>  ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -65,7 +66,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create denominator table
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -78,7 +79,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerator table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -96,7 +97,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Create surrogate table
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t	surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -122,8 +123,8 @@ echo "CREATE TABLE $schema.surg_${surg_code}_${grid}; add primary key"
 $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_code}_surg.sql
 
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_polygon_noFF_noWA.csh
+++ b/pgscripts/template_polygon_noFF_noWA.csh
@@ -3,6 +3,8 @@
 # AFTER sucessful completion of acs_2014_prcs_script.sh; performs grid overlay and related calculations
 # handles reprojections of geometry objects (geographic polygons), vacuum, analyze, and cluster as appropriate
 
+setenv PGPASSWORD satool
+
 VAR_DEFINITIONS
 
 setenv cluster false					
@@ -73,7 +75,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -90,7 +92,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -104,7 +106,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      colnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      rownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      surg double precision,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -131,8 +133,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_polygon_noFF_noWA.csh
+++ b/pgscripts/template_polygon_noFF_noWA.csh
@@ -3,8 +3,6 @@
 # AFTER sucessful completion of acs_2014_prcs_script.sh; performs grid overlay and related calculations
 # handles reprojections of geometry objects (geographic polygons), vacuum, analyze, and cluster as appropriate
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 setenv cluster false					

--- a/pgscripts/template_polygon_noFF_withWA.csh
+++ b/pgscripts/template_polygon_noFF_withWA.csh
@@ -3,6 +3,8 @@
 # AFTER sucessful completion of acs_2014_prcs_script.sh; performs grid overlay and related calculations
 # handles reprojections of geometry objects (geographic polygons), vacuum, analyze, and cluster as appropriate
 
+setenv PGPASSWORD satool
+
 VAR_DEFINITIONS
 
 setenv cluster false					
@@ -93,7 +95,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -110,7 +112,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -124,7 +126,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      colnum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      rownum integer not null,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      surg double precision,\n" >>  ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -151,8 +153,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}

--- a/pgscripts/template_polygon_noFF_withWA.csh
+++ b/pgscripts/template_polygon_noFF_withWA.csh
@@ -3,8 +3,6 @@
 # AFTER sucessful completion of acs_2014_prcs_script.sh; performs grid overlay and related calculations
 # handles reprojections of geometry objects (geographic polygons), vacuum, analyze, and cluster as appropriate
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 setenv cluster false					

--- a/pgscripts/template_polygon_withFF_noWA.csh
+++ b/pgscripts/template_polygon_withFF_noWA.csh
@@ -3,8 +3,6 @@
 # AFTER sucessful completion of acs_2014_prcs_script.sh; performs grid overlay and related calculations
 # handles reprojections of geometry objects (geographic polygons), vacuum, analyze, and cluster as appropriate
 
-setenv PGPASSWORD satool
-
 VAR_DEFINITIONS
 
 setenv cluster false					

--- a/pgscripts/template_polygon_withFF_noWA.csh
+++ b/pgscripts/template_polygon_withFF_noWA.csh
@@ -3,6 +3,8 @@
 # AFTER sucessful completion of acs_2014_prcs_script.sh; performs grid overlay and related calculations
 # handles reprojections of geometry objects (geographic polygons), vacuum, analyze, and cluster as appropriate
 
+setenv PGPASSWORD satool
+
 VAR_DEFINITIONS
 
 setenv cluster false					
@@ -20,7 +22,7 @@ echo $data_table
 # cut with geographic boundaries
 printf "DROP TABLE IF EXISTS ${schema_name}.wp_cty_${surg_code};\n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "CREATE TABLE ${schema_name}.wp_cty_${surg_code}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
-printf "\t(${data_attribute} varchar (6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\t(${data_attribute} varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\tarea_${srid_final} double precision default 0.0);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "SELECT AddGeometryColumn('${schema_name}', 'wp_cty_${surg_code}', 'geom_${srid_final}', ${srid_final}, 'MultiPolygon', 2);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 
@@ -35,7 +37,8 @@ printf "\t\tST_CollectionExtract(ST_Multi(ST_Intersection(${geom_weight},${geom_
 printf "\tEND AS geom_${srid_final}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\tFROM ${data_table}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\tJOIN ${weight_table}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
-printf "\tON (NOT ST_Touches(${geom_weight},${geom_data})\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\tON ${geom_weight} && ${geom_data}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
+printf "\tAND (NOT ST_Touches(${geom_weight},${geom_data})\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\t\tAND ST_Intersects(${geom_weight},${geom_data}))\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "\twhere ${weight_table}.${filter_function}; \n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
 printf "update  ${schema_name}.wp_cty_${surg_code} set area_${srid_final}=ST_Area(geom_${srid_final});\n"  >> ${output_dir}/temp_files/${surg_code}_create_wp_cty.sql
@@ -48,7 +51,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # create query to grid weight data
 printf "DROP TABLE IF EXISTS wp_cty_cell_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 echo "CREATE TABLE ${schema_name}.wp_cty_cell_${surg_code}_${grid} (" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "\t${data_attribute} varchar (6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\t${data_attribute} varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tarea_${srid_final} double precision default 1.0);\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -65,7 +68,8 @@ printf "\t\t\tST_CollectionExtract(ST_Multi(ST_Intersection(${schema}.wp_cty_${s
 printf "\t\tEND AS geom_${srid_final}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tFROM ${schema}.wp_cty_${surg_code}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\tJOIN ${grid_table}\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
-printf "\tON (NOT ST_Touches(${schema}.wp_cty_${surg_code}.geom_${grid_proj}, ${grid_table}.gridcell)\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\tON ${schema}.wp_cty_${surg_code}.geom_${grid_proj} && ${grid_table}.gridcell\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
+printf "\tAND (NOT ST_Touches(${schema}.wp_cty_${surg_code}.geom_${grid_proj}, ${grid_table}.gridcell)\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "\t\tAND ST_Intersects(${schema}.wp_cty_${surg_code}.geom_${grid_proj}, ${grid_table}.gridcell));\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "UPDATE ${schema_name}.wp_cty_cell_${surg_code}_${grid} set area_${srid_final}=ST_Area(geom_${srid_final});\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
 printf "create index  on $schema.wp_cty_cell_${surg_code}_${grid} using GIST(geom_${grid_proj});\n" >> ${output_dir}/temp_files/${surg_code}_create_wp_cty_cell.sql
@@ -75,7 +79,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Create numerater table
 printf "DROP TABLE IF EXISTS $schema.numer_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_numer.sql
-printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
+printf "CREATE TABLE $schema.numer_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tcolnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\trownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
 printf "\tnumer double precision,\n" >> ${output_dir}/temp_files/${surg_code}_numer.sql
@@ -92,7 +96,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Calculate donominator
 printf "DROP TABLE IF EXISTS $schema.denom_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_denom.sql
-printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
+printf "CREATE TABLE $schema.denom_${surg_code}_${grid} ($data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tdenom double precision,\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "\tprimary key ($data_attribute));\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
 printf "insert into $schema.denom_${surg_code}_${grid}\n" >> ${output_dir}/temp_files/${surg_code}_denom.sql
@@ -106,7 +110,7 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 # Calculate surrogate
 printf "DROP TABLE IF EXISTS $schema.surg_${surg_code}_${grid}; \n" > ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "CREATE TABLE $schema.surg_${surg_code}_${grid} (surg_code integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
-printf "\t$data_attribute varchar(5) not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
+printf "\t$data_attribute varchar(6) not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      colnum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      rownum integer not null,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
 printf "\t      surg double precision,\n" >> ${output_dir}/temp_files/${surg_code}_surg.sql
@@ -133,8 +137,8 @@ $PGBIN/psql -h $server -d $dbname -U $user -f ${output_dir}/temp_files/${surg_co
 
 # Export surrogate
 echo "Exporting surrogates $schema.surg_${surg_code}_${grid}; "
-echo "#GRID" > ${output_dir}/USA_${surg_code}_NOFILL.txt
-$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/USA_${surg_code}_NOFILL.txt
+echo "#GRID" > ${output_dir}/${region}_${surg_code}_NOFILL.txt
+$PGBIN/psql -h $server -d $dbname -U $user --field-separator '	' -t --no-align << END >> ${output_dir}/${region}_${surg_code}_NOFILL.txt
 
 SELECT surg_code, ${data_attribute}, colnum, rownum, ROUND(surg::NUMERIC, 10), '!', numer, denom
   FROM $schema.surg_${surg_code}_${grid}


### PR DESCRIPTION
Extend the FIPS from varchar 5 to 6 in the templates. Change the hardcoded US country prefix for the surrogate outputs to the region variable. These are done to support non-US countries and for compatibility with the old surrogate tool.